### PR TITLE
fix: normalizeUrlFile might get undefined

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -82,7 +82,7 @@ exports.getWebpackConfig = (eggWebpackConfig, option) => {
 };
 
 exports.normalizeUrlFile = (baseDir, url, publicPath, buildPath) => {
-  const normalizeBuildPath = buildPath.replace(baseDir).replace(/^\//, '').replace(/\/$/, '');
+  const normalizeBuildPath = buildPath.replace(baseDir, '').replace(/^\//, '').replace(/\/$/, '');
   const normalizeUrl = url.replace(publicPath, `/${normalizeBuildPath}/`);
   return path.join(baseDir, normalizeUrl);
 };


### PR DESCRIPTION
`buildPath.replace(baseDir)` needs second argument `''`, otherwise it will replace the `baseDir` with `undefined`.