### PR TITLE
feat: get real port by egg-ready event

### DIFF
--- a/agent.js
+++ b/agent.js
@@ -3,8 +3,9 @@ const Utils = require('./lib/utils');
 const WebpackServer = require('./lib/server');
 const MultProcessWebpackServer = require('./lib/mult-process-server');
 module.exports = agent => {
-  agent.messenger.on('egg-ready', () => {
+  agent.messenger.on('egg-ready', ({ port }) => {
     const config = agent.config.webpack;
+    config.appPort = port;
     agent.messenger.setMaxListeners(config.maxListeners || 10000);
     // 兼容 Node 前端渲染只有一个 webpack 配置
     if (config.webpackConfigList && !Array.isArray(config.webpackConfigList)) {


### PR DESCRIPTION
在 egg-ready 事件中是可以获取到当前真正在运行的端口